### PR TITLE
Make more robust for multi-value rules

### DIFF
--- a/h5p-show-when.js
+++ b/h5p-show-when.js
@@ -2,6 +2,10 @@ H5PEditor.ShowWhen = (function ($) {
 
   // Handler for the 'select' semantics type
   function SelectHandler(field, equals) {
+    if (typeof equals === 'string') {
+      equals = [equals];
+    }
+
     this.satisfied = function () {
       return (equals.indexOf(field.value) !== -1);
     };
@@ -9,6 +13,10 @@ H5PEditor.ShowWhen = (function ($) {
 
   // Handler for the 'library' semantics type
   function LibraryHandler(field, equals) {
+    if (typeof equals === 'string') {
+      equals = [equals];
+    }
+
     this.satisfied = function () {
       var value;
       if (field.currentLibrary !== undefined && field.params.library) {


### PR DESCRIPTION
The show-when widget currently allows to hold an array for a rule's `equals` property. That's handy if there are multiple string values to check against. A developer could, however, like I just did, set up multiple rules for the same field just holding a string for the `equals` property. In that case, the `indexOf`function will run on a string and will also hit on strings that contain the `equals` property leading to triggering on false positives.

When this pull-request is merged in, that issue will be fixed.