### PR TITLE
Relay changes from followed field

### DIFF
--- a/h5p-show-when.js
+++ b/h5p-show-when.js
@@ -122,13 +122,15 @@ H5PEditor.ShowWhen = (function ($) {
     var fieldInstance = new H5PEditor.widgets[widgetName](parent, field, params, setValue);
     fieldInstance.appendTo($wrapper);
 
-    // Forward value changes from original field
-    fieldInstance.changes.push(function (value) {
-      for (var i = 0; i < self.changes.length; i++) {
-        self.value = value;
-        self.changes[i](value);
-      }
-    });
+    if (fieldInstance.changes) {
+      // Forward value changes from original field
+      fieldInstance.changes.push(function (value) {
+        for (var i = 0; i < self.changes.length; i++) {
+          self.value = value;
+          self.changes[i](value);
+        }
+      });
+    }
 
     /**
      * Add myself to the DOM

--- a/h5p-show-when.js
+++ b/h5p-show-when.js
@@ -77,6 +77,9 @@ H5PEditor.ShowWhen = (function ($) {
     self.passReadies = true;
     self.value = params;
 
+    // Allow other fields to listen to changes to original field
+    self.changes = [];
+
     // Create the wrapper:
     var $wrapper = $('<div>', {
       'class': 'field h5p-editor-widget-show-when'
@@ -118,6 +121,14 @@ H5PEditor.ShowWhen = (function ($) {
     var widgetName = config.widget || field.type;
     var fieldInstance = new H5PEditor.widgets[widgetName](parent, field, params, setValue);
     fieldInstance.appendTo($wrapper);
+
+    // Forward value changes from original field
+    fieldInstance.changes.push(function (value) {
+      for (var i = 0; i < self.changes.length; i++) {
+        self.value = value;
+        self.changes[i](value);
+      }
+    });
 
     /**
      * Add myself to the DOM


### PR DESCRIPTION
When merged in, the ShowWhen widget will relay changes from the original field to other fields that may want to listen to that field. Will also fix consecutive ShowWhen widgets as described in https://github.com/h5p/h5p-editor-show-when/issues/1