### PR TITLE
Fix detection of library change

### DIFF
--- a/h5p-show-when.js
+++ b/h5p-show-when.js
@@ -11,7 +11,7 @@ H5PEditor.ShowWhen = (function ($) {
   function LibraryHandler(field, equals) {
     this.satisfied = function () {
       var value;
-      if (field.currentLibrary !== undefined) {
+      if (field.currentLibrary !== undefined && field.params.library) {
         value = field.currentLibrary.split(' ')[0];
       }
       return (equals.indexOf(value) !== -1);


### PR DESCRIPTION
When changing a library back to the default "-" value, the `currentLibrary` property still held the old Library and a change is not reported properly. Fixed when merged in.