### PR TITLE
Fix the TYPE_and type in RuleHandler

### DIFF
--- a/h5p-show-when.js
+++ b/h5p-show-when.js
@@ -64,7 +64,7 @@ H5PEditor.ShowWhen = (function ($) {
         }
       }
 
-      return false;
+      return (type === TYPE_AND);
     };
   }
 

--- a/h5p-show-when.js
+++ b/h5p-show-when.js
@@ -51,9 +51,7 @@ H5PEditor.ShowWhen = (function ($) {
     };
 
     // Check if rules are satisfied
-    this.rulesSatisfied = function (ruleslength) {
-      // Initialize the number of rules in a TYPE_AND field
-      var andRulesNb = 0;
+    this.rulesSatisfied = function () {
       for (var i = 0; i < handlers.length; i++) {
         // check if rule was hit
         var ruleHit = handlers[i].satisfied();
@@ -61,12 +59,8 @@ H5PEditor.ShowWhen = (function ($) {
         if (ruleHit && type === TYPE_OR) {
           return true;
         }
-        else if (type === TYPE_AND && ruleHit) {
-            // Increment the number of rules in a TYPE_AND field.
-            andRulesNb ++
-            if (andRulesNb === ruleslength) {
-              return true;
-            }
+        else if (type === TYPE_AND && !ruleHit) {
+          return false;
         }
       }
 
@@ -95,14 +89,11 @@ H5PEditor.ShowWhen = (function ($) {
     }
 
     var ruleHandler = new RuleHandler(config.type);
-    // Get the number of rules in a TYPE_AND field.
-    var ruleslength = config.rules.length;
-    
+
     for (var i = 0; i < config.rules.length; i++) {
       var rule = config.rules[i];
       var targetField = H5PEditor.findField(rule.field, parent);
-      // Pass the ruleslength value to the handler
-      var handler = createFieldHandler(targetField, rule.equals, ruleslength);
+      var handler = createFieldHandler(targetField, rule.equals);
 
       if (handler !== undefined) {
         ruleHandler.add(handler);
@@ -117,8 +108,7 @@ H5PEditor.ShowWhen = (function ($) {
             }
           }
         } : function () {
-          // Pass the ruleslength value to "showing".
-          showing = ruleHandler.rulesSatisfied(ruleslength);
+          showing = ruleHandler.rulesSatisfied();
           $wrapper.toggleClass('hidden', !showing);
         });
       }

--- a/h5p-show-when.js
+++ b/h5p-show-when.js
@@ -51,7 +51,9 @@ H5PEditor.ShowWhen = (function ($) {
     };
 
     // Check if rules are satisfied
-    this.rulesSatisfied = function () {
+    this.rulesSatisfied = function (ruleslength) {
+      // Initialize the number of rules in a TYPE_AND field
+      var andRulesNb = 0;
       for (var i = 0; i < handlers.length; i++) {
         // check if rule was hit
         var ruleHit = handlers[i].satisfied();
@@ -59,8 +61,12 @@ H5PEditor.ShowWhen = (function ($) {
         if (ruleHit && type === TYPE_OR) {
           return true;
         }
-        else if (type === TYPE_AND && !ruleHit) {
-          return false;
+        else if (type === TYPE_AND && ruleHit) {
+            // Increment the number of rules in a TYPE_AND field.
+            andRulesNb ++
+            if (andRulesNb === ruleslength) {
+              return true;
+            }
         }
       }
 
@@ -89,11 +95,14 @@ H5PEditor.ShowWhen = (function ($) {
     }
 
     var ruleHandler = new RuleHandler(config.type);
-
+    // Get the number of rules in a TYPE_AND field.
+    var ruleslength = config.rules.length;
+    
     for (var i = 0; i < config.rules.length; i++) {
       var rule = config.rules[i];
       var targetField = H5PEditor.findField(rule.field, parent);
-      var handler = createFieldHandler(targetField, rule.equals);
+      // Pass the ruleslength value to the handler
+      var handler = createFieldHandler(targetField, rule.equals, ruleslength);
 
       if (handler !== undefined) {
         ruleHandler.add(handler);
@@ -108,7 +117,8 @@ H5PEditor.ShowWhen = (function ($) {
             }
           }
         } : function () {
-          showing = ruleHandler.rulesSatisfied();
+          // Pass the ruleslength value to "showing".
+          showing = ruleHandler.rulesSatisfied(ruleslength);
           $wrapper.toggleClass('hidden', !showing);
         });
       }

--- a/h5p-show-when.js
+++ b/h5p-show-when.js
@@ -75,7 +75,9 @@ H5PEditor.ShowWhen = (function ($) {
     self.field = field;
     // Outsource readies
     self.passReadies = true;
-    self.value = params;
+    self.value = params; 
+    // Allow other fields to listen to changes to original field
+    self.changes = [];    
 
     // Create the wrapper:
     var $wrapper = $('<div>', {
@@ -117,7 +119,18 @@ H5PEditor.ShowWhen = (function ($) {
     // Create the real field:
     var widgetName = config.widget || field.type;
     var fieldInstance = new H5PEditor.widgets[widgetName](parent, field, params, setValue);
-    fieldInstance.appendTo($wrapper);
+    fieldInstance.appendTo($wrapper); 
+    // Forward value changes from original field
+    
+    if (fieldInstance.changes) {
+      // Forward value changes from original field
+      fieldInstance.changes.push(function (value) {
+        for (var i = 0; i < self.changes.length; i++) {
+          self.value = value;
+          self.changes[i](value);
+        }
+      });
+    } 
 
     /**
      * Add myself to the DOM

--- a/library.json
+++ b/library.json
@@ -1,5 +1,5 @@
 {
-  "machineName": "H5PEditor.ShowWhen",
+  "machineName": "H5PEditor.ShowWhenpapijo",
   "title": "Toggle visibility of a field based on rules",
   "license": "MIT",
   "author": "fnoks",


### PR DESCRIPTION
Signed-off-by: rezeau <joseph@rezeau.org>
The "and" type does not work currently in ShowWhen. My fix retrieves the number of rules in such a type.
Example for testing:
<pre><code>[
  {
    "name": "condition1",
    "label": "condition 1",
    "type": "boolean"
  },
  {
    "name": "condition2",
    "label": "condition 2",
    "type": "boolean"
  },
  {
    "name": "condition3",
    "label": "condition 3",
    "type": "boolean"
  },
  {
    "name": "result1",
    "label": "RESULT 1 type = and; conditions 1 & 2 = true; condition 3 = false",
    "type": "boolean",
    "widget": "showWhen",
    "showWhen": {
      "type": "and",    
        "rules": [
        {
          "field": "condition1",
          "equals": true
        },
        {
          "field": "condition2",
          "equals": true
        },
        {
          "field": "condition3",
          "equals": false
        }
      ]
    } 
  },     
  {
    "name": "result2",
    "label": "RESULT 2 type = or; conditions 1 & 2 = true; condition 3 = false",
    "type": "boolean",
    "widget": "showWhen",
    "showWhen": {
      "type": "or",    
        "rules": [
        {
          "field": "condition1",
          "equals": true
        },
        {
          "field": "condition2",
          "equals": true
        },
        {
          "field": "condition3",
          "equals": false
        }
      ]
    } 
  }  
]</code></pre>