### PR TITLE
Fix default return value of AND rule handler

### DIFF
--- a/h5p-show-when.js
+++ b/h5p-show-when.js
@@ -64,7 +64,7 @@ H5PEditor.ShowWhen = (function ($) {
         }
       }
 
-      return false;
+      return (type === TYPE_AND);
     };
   }
 


### PR DESCRIPTION
The problem with the rule handler was the default return value that was returned when no rule lead to an early resolution. It was always false while it should have been true for rules of AND type and only false for rules of OR type. Fixed here.