### PR TITLE
Fix removing field value when field hidden

### DIFF
--- a/h5p-show-when.js
+++ b/h5p-show-when.js
@@ -115,7 +115,7 @@ H5PEditor.ShowWhen = (function ($) {
           }
 
           if (config.nullWhenHidden && !ruleHandler.rulesSatisfied()) {
-            setValue(self.field, null);
+            setValue(self.field, undefined);
           }
         });
       }


### PR DESCRIPTION
The current implementation for the `nullWhenHidden` implementation will set the value of a field to `null` when a rule is not satisfied and the field is hidden. This will end up in H5P editor core at https://github.com/h5p/h5p-editor-php-library/blob/f712ee5963c2904eba6c993bc8c430c327f0d07f/scripts/h5peditor.js#L483-L488 where it expects `undefined` if a value should be removed. In consequence, a the value of a text field will not be deleted, but set to the string "null".

When merged in, despite the option's name being `nullWhenHidden`, the value will be set to `undefined` in order to achieve the desired effect. Optionally, of course, the H5P editor core could be changed to also check for `null`.