### PR TITLE
HFP-4196 Pass trough children property of field instance

### DIFF
--- a/h5p-show-when.js
+++ b/h5p-show-when.js
@@ -126,6 +126,8 @@ H5PEditor.ShowWhen = (function ($) {
     var fieldInstance = new H5PEditor.widgets[widgetName](parent, field, params, setValue);
     fieldInstance.appendTo($wrapper);
 
+    self.children = fieldInstance.children;
+    
     if (typeof fieldInstance.change === 'function') {
       self.change = function (callback) {
         fieldInstance.change(callback);


### PR DESCRIPTION
When merged in, will pass through `children` property of field instance that the widget is applied to.

If another editor widget needs to know about the children of the field instance, e.g. in order to find a field using [`H5PEditor.findField`](https://github.com/otacke/h5p-editor-php-library/blob/master/scripts/h5peditor.js#L667C4-L691), this is currently not possible.